### PR TITLE
Add options for 'Run Tests' command

### DIFF
--- a/src/project/cli-cmds/test.ts
+++ b/src/project/cli-cmds/test.ts
@@ -2,22 +2,55 @@ import { ballerinaExtInstance } from "../../core";
 import { commands, window } from "vscode";
 import { TM_EVENT_RUN_PROJECT_TESTS, CMP_PROJECT_TEST_RUNNER } from "../../telemetry";
 import { runCommand, BALLERINA_COMMANDS } from "./cmd-runner";
-import { getCurrentBallerinaProject } from "./utils";
+import { getCurrentBallerinaProject, getCurrentBallerinaFile } from "./utils";
 
 export function activateTestRunner() {
     const reporter = ballerinaExtInstance.telemetryReporter;
 
     // register run project tests handler
-    commands.registerCommand('ballerina.project.test', () => {
-        reporter.sendTelemetryEvent(TM_EVENT_RUN_PROJECT_TESTS, { component: CMP_PROJECT_TEST_RUNNER });
-        // get Ballerina Project path for current Ballerina file
-        getCurrentBallerinaProject().then((project) => {
-            if (project) {
-                runCommand(project, BALLERINA_COMMANDS.TEST);
+    commands.registerCommand('ballerina.project.test', async () => {
+        try {
+            reporter.sendTelemetryEvent(TM_EVENT_RUN_PROJECT_TESTS, { component: CMP_PROJECT_TEST_RUNNER });
+            // get Ballerina Project path for current Ballerina file
+            const currentProject = await getCurrentBallerinaProject();
+            if (currentProject) {
+                const testRunOptions = [
+                    {
+                        'description': 'ballerina test <balfile>',
+                        'label': 'Run tests on the current file',
+                        'id': 'test-file'
+                    },
+                    {
+                        'description': 'ballerina test <module-name>',
+                        'label': 'Run modules tests',
+                        'id': 'test-module'
+                    },
+                    {
+                        'description': 'ballerina test --all',
+                        'label': 'Run all tests in project',
+                        'id': 'test-all'
+                    }
+                ];
+                const userSelection = await window.showQuickPick(testRunOptions, { placeHolder: 'Select test run option.' });
+                if (userSelection!.id === 'test-file') {
+                    runCommand(currentProject, BALLERINA_COMMANDS.TEST, getCurrentBallerinaFile());
+                }
+
+                if (userSelection!.id === 'test-module') {
+                    let moduleName;
+                    do {
+                        moduleName = await window.showInputBox({ placeHolder: 'Enter module name.' });
+                    } while (!moduleName || moduleName && moduleName.trim().length === 0);
+                    runCommand(currentProject, BALLERINA_COMMANDS.TEST, moduleName);
+                }
+
+                if (userSelection!.id === 'test-all') {
+                    runCommand(currentProject, BALLERINA_COMMANDS.TEST, '--all');
+                }
             }
-        }, (reason) => {
-            reporter.sendTelemetryException(reason, { component: CMP_PROJECT_TEST_RUNNER });
-            window.showErrorMessage(reason);
-        });
+        } catch (error) {
+            reporter.sendTelemetryException(error, { component: CMP_PROJECT_TEST_RUNNER });
+            window.showErrorMessage(error);
+        }
     });
 }

--- a/src/project/cli-cmds/utils.ts
+++ b/src/project/cli-cmds/utils.ts
@@ -1,7 +1,7 @@
 import { BallerinaProject, ballerinaExtInstance } from "../../core";
 import { window } from "vscode";
 
-export function getCurrentBallerinaProject() : Promise<BallerinaProject> {
+function getCurrentBallerinaProject(): Promise<BallerinaProject> {
     return new Promise((resolve, reject) => {
         const activeEditor = window.activeTextEditor;
         // if currently opened file is a bal file
@@ -23,3 +23,13 @@ export function getCurrentBallerinaProject() : Promise<BallerinaProject> {
         }
     });
 }
+
+function getCurrentBallerinaFile(): string {
+    const activeEditor = window.activeTextEditor;
+    if (activeEditor && activeEditor.document.fileName.endsWith('.bal')) {
+        return activeEditor.document.fileName.toString();
+    }
+    throw new Error("Current file is not a Ballerina file");
+}
+
+export { getCurrentBallerinaProject, getCurrentBallerinaFile };


### PR DESCRIPTION
## Purpose
Add the following options for 'Ballerina: Run Project Tests' command.
- Run tests on the current file
- Run tests on a specified module
- Run all tests in the project

Fix https://github.com/ballerina-platform/plugin-vscode/issues/12