### PR TITLE
Add 'Run module with Choreo observability' option

### DIFF
--- a/src/project/cli-cmds/build.ts
+++ b/src/project/cli-cmds/build.ts
@@ -11,43 +11,45 @@ export function activateBuildCommand() {
     commands.registerCommand('ballerina.project.build', async () => {
         try {
             reporter.sendTelemetryEvent(TM_EVENT_RUN_PROJECT_BUILD, { component: CMP_PROJECT_BUILD });
-            let buildOptions: { description: string, label: string, id: string }[] = [
-                {
-                    description: "ballerina build <balfile>",
-                    label: "Build current file",
-                    id: "build-file"
-                }
-            ];
 
             const currentProject = await getCurrentBallerinaProject();
             if (currentProject.path) {
-                buildOptions.push({
-                    description: "ballerina build <module-name>",
-                    label: "Build module",
-                    id: "build-module"
-                }, {
-                    description: "ballerina build --all",
-                    label: "Build project",
-                    id: "build-all"
-                });
-            }
+                const buildOptions = [
+                    {
+                        description: "ballerina build <balfile>",
+                        label: "Build current file",
+                        id: "build-file"
+                    }, {
+                        description: "ballerina build <module-name>",
+                        label: "Build module",
+                        id: "build-module"
+                    }, {
+                        description: "ballerina build --all",
+                        label: "Build project",
+                        id: "build-all"
+                    }
+                ];
 
-            const userSelection = await window.showQuickPick(buildOptions, { placeHolder: 'Select a build option.' });
-            if (userSelection!.id === 'build-file') {
+                const userSelection = await window.showQuickPick(buildOptions, { placeHolder: 'Select a build option.' });
+                if (userSelection!.id === 'build-file') {
+                    runCommand(getCurrenDirectoryPath(), BALLERINA_COMMANDS.BUILD, getCurrentBallerinaFile());
+                }
+
+                if (userSelection!.id === 'build-module') {
+                    let moduleName;
+                    do {
+                        moduleName = await window.showInputBox({ placeHolder: 'Enter module name.' });
+                    } while (!moduleName || moduleName && moduleName.trim().length === 0);
+                    runCommand(currentProject, BALLERINA_COMMANDS.BUILD, moduleName);
+                }
+
+                if (userSelection!.id === 'build-all') {
+                    runCommand(currentProject, BALLERINA_COMMANDS.BUILD, "--all");
+                }
+            } else {
                 runCommand(getCurrenDirectoryPath(), BALLERINA_COMMANDS.BUILD, getCurrentBallerinaFile());
             }
 
-            if (userSelection!.id === 'build-module') {
-                let moduleName;
-                do {
-                    moduleName = await window.showInputBox({ placeHolder: 'Enter module name.' });
-                } while (!moduleName || moduleName && moduleName.trim().length === 0);
-                runCommand(currentProject, BALLERINA_COMMANDS.BUILD, moduleName);
-            }
-
-            if (userSelection!.id === 'build-all') {
-                runCommand(currentProject, BALLERINA_COMMANDS.BUILD, "--all");
-            }
         } catch (error) {
             reporter.sendTelemetryException(error, { component: CMP_PROJECT_BUILD });
             window.showErrorMessage(error);


### PR DESCRIPTION
## Purpose
Add **Run module with Choreo observability** option for the run command `ballerina run --observability-included <module_name> --b7a.observability.enabled=true --b7a.observability.provider=choreo`, and remove user options for single file executions.

Related issue: https://github.com/ballerina-platform/plugin-vscode/issues/32
