### PR TITLE
Change default debugger networkLogs to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
                         "request": "launch",
                         "name": "Ballerina Debug",
                         "script": "${file}",
-                        "networkLogs": true
+                        "networkLogs": false
                     },
                     {
                         "type": "ballerina",

--- a/src/debugger/config-provider.ts
+++ b/src/debugger/config-provider.ts
@@ -81,7 +81,7 @@ async function getModifiedConfigs(config: DebugConfiguration) {
         if (experimental && experimental.introspection && experimental.introspection.port > 0) {
             config.networkLogsPort = experimental.introspection.port;
             if (config.networkLogs === undefined) {
-                config.networkLogs = true;
+                config.networkLogs = false;
             }
         }
     }


### PR DESCRIPTION

## Purpose
Change the default debugger networkLogs configuration to false, to avoid unnecessary logs.