### PR TITLE
Improve error handling of ballerina version detecting logic

### DIFF
--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -290,11 +290,16 @@ export class BallerinaExtension {
         let ballerinaExecutor = '';
         const balPromise: Promise<string> = new Promise((resolve, reject) => {
             exec(distPath + 'bal' + exeExtension + ' version', (_err, stdout, stderr) => {
-                const cmdOutput = stdout.length > 0 ? stdout : stderr;
-                if (cmdOutput.startsWith(ERROR) || cmdOutput.includes(NO_SUCH_FILE) || cmdOutput.includes(COMMAND_NOT_FOUND)) {
-                    reject(cmdOutput);
+                if (_err) {
+                    reject(_err);
                     return;
                 }
+
+                if (stdout.length === 0 || stdout.startsWith(ERROR) || stdout.includes(NO_SUCH_FILE) || stdout.includes(COMMAND_NOT_FOUND)) {
+                    reject(stdout);
+                    return;
+                }
+
                 ballerinaExecutor = 'bal';
                 log(`'bal' command is picked up from the plugin.`);
                 resolve(stdout);
@@ -302,11 +307,16 @@ export class BallerinaExtension {
         });
         const ballerinaPromise: Promise<string> = new Promise((resolve, reject) => {
             exec(distPath + 'ballerina' + exeExtension + ' version', (_err, stdout, stderr) => {
-                const cmdOutput = stdout.length > 0 ? stdout : stderr;
-                if (cmdOutput.startsWith(ERROR) || cmdOutput.includes(NO_SUCH_FILE) || cmdOutput.includes(COMMAND_NOT_FOUND)) {
-                    reject(cmdOutput);
+                if (_err) {
+                    reject(_err);
                     return;
                 }
+
+                if (stdout.length === 0 || stdout.startsWith(ERROR) || stdout.includes(NO_SUCH_FILE) || stdout.includes(COMMAND_NOT_FOUND)) {
+                    reject(stdout);
+                    return;
+                }
+
                 ballerinaExecutor = 'ballerina';
                 log(`'ballerina' command is picked up from the plugin.`);
                 resolve(stdout);

--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -289,9 +289,9 @@ export class BallerinaExtension {
 
         let ballerinaExecutor = '';
         const balPromise: Promise<string> = new Promise((resolve, reject) => {
-            exec(distPath + 'bal' + exeExtension + ' version', (_err, stdout, stderr) => {
-                if (_err) {
-                    reject(_err);
+            exec(distPath + 'bal' + exeExtension + ' version', (err, stdout, _stderr) => {
+                if (err) {
+                    reject(err);
                     return;
                 }
 
@@ -306,9 +306,9 @@ export class BallerinaExtension {
             });
         });
         const ballerinaPromise: Promise<string> = new Promise((resolve, reject) => {
-            exec(distPath + 'ballerina' + exeExtension + ' version', (_err, stdout, stderr) => {
-                if (_err) {
-                    reject(_err);
+            exec(distPath + 'ballerina' + exeExtension + ' version', (err, stdout, _stderr) => {
+                if (err) {
+                    reject(err);
                     return;
                 }
 


### PR DESCRIPTION
## Purpose
Fixes #198. 

## Approach

Updated the handling of the exec command results to reject the promise if an error is returned by the `exec` command's . The first parameter (`error`) passed in to the [`exec` method's callback](https://nodejs.org/dist/latest-v14.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback) represents an error if the command execution fails (non zero exit code). The error is `null` otherwise. I have used this to improve error handling of ballerina version detection.