### PR TITLE
Add support to configure environmental variables in debug launch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
                             },
                             "scriptArguments": [],
                             "commandOptions": [],
+                            "env": {},
                             "debugServerTimeout": {
                                 "type": "integer",
                                 "default": 5000,

--- a/src/debugger/model.ts
+++ b/src/debugger/model.ts
@@ -15,6 +15,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     networkLogs: Boolean;
     networkLogsPort: number;
     port: number;
+    env: Map<string,string>;
 }
 
 export interface RunningInfo {

--- a/src/debugger/model.ts
+++ b/src/debugger/model.ts
@@ -10,17 +10,17 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     script: string;
     scriptArguments: Array<string>;
     commandOptions: Array<string>;
-    'ballerina.home': string; 
+    'ballerina.home': string;
     debugTests: boolean;
     networkLogs: Boolean;
     networkLogsPort: number;
     port: number;
-    env: Map<string,string>;
+    env: Map<string, string>;
 }
 
 export interface RunningInfo {
-    sourceRoot? : string;
-    ballerinaPackage? : string;
+    sourceRoot?: string;
+    ballerinaPackage?: string;
 }
 
 export interface ProjectConfig {


### PR DESCRIPTION
## Purpose
This PR adds support to configure environmental variables in debug launch mode, which can be configured in `launch.json` as follows.

Fixes ballerina-platform/plugin-vscode#3.

![Screenshot from 2021-02-23 15-23-13](https://user-images.githubusercontent.com/29032600/108828230-9b1c8000-75ec-11eb-8b64-266f4d1f557b.png)

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/28842

