### PR TITLE
Increase mocha test default timeout

### DIFF
--- a/test/debugger/debugger.test.ts
+++ b/test/debugger/debugger.test.ts
@@ -90,7 +90,7 @@ suite('Ballerina Debug Adapter', () => {
         //     const response = await dc.initializeRequest();
         //     response.body = response.body || {};
         //     assert.equal(response.body.supportsConfigurationDoneRequest, true, 'Invalid config done rquest.');
-        // }).timeout(30000);
+        // }).timeout(20000);
 
         // test('launch request', async () => {
         //     const program = path.join(DATA_ROOT, 'hello_world.bal');
@@ -106,7 +106,7 @@ suite('Ballerina Debug Adapter', () => {
 
         //     assert.equal(response.success, true, 'Invalid response state.');
         //     assert.equal(response.command, 'launch', 'Invalid response command.');
-        // }).timeout(30000);
+        // }).timeout(20000);
 
         test('should stop on a breakpoint, main function', async () => {
             const program = path.join(DATA_ROOT, 'hello_world.bal');
@@ -120,7 +120,7 @@ suite('Ballerina Debug Adapter', () => {
                 "debuggeePort": debuggeePort
             };
             return await dc.hitBreakpoint(launchArgs, { path: program, line: 5 });
-        }).timeout(30000);
+        }).timeout(20000);
 
         test('should stop on a breakpoint, hello world service', async () => {
             const program = path.join(DATA_ROOT, 'hello_world_service.bal');
@@ -140,7 +140,7 @@ suite('Ballerina Debug Adapter', () => {
                 }
             });
             return await dc.hitBreakpoint(launchArgs, { path: program, line: 11 });
-        }).timeout(30000);
+        }).timeout(20000);
 
         test('should stop on a breakpoint, hello world service - package', async () => {
             const program = path.join(DATA_ROOT, 'helloServicePackage', 'hello_service.bal');
@@ -160,7 +160,7 @@ suite('Ballerina Debug Adapter', () => {
                 }
             });
             return await dc.hitBreakpoint(launchArgs, { path: program, line: 11 });
-        }).timeout(30000);
+        }).timeout(20000);
 
         test('step In, hello world service - package', async () => {
             const program = path.join(DATA_ROOT, 'helloPackage', 'modules', 'hello', 'hello_service.bal');
@@ -214,7 +214,7 @@ suite('Ballerina Debug Adapter', () => {
                     });
                 })
             ]);
-        }).timeout(100000);
+        }).timeout(50000);
     });
 });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -26,6 +26,7 @@ if (!tty.getWindowSize) {
 let mocha = new Mocha({
     ui: "tdd",
     useColors: true,
+    timeout: 10000
 });
 
 function configure(mochaOpts: any): void {


### PR DESCRIPTION
## Purpose
Increase mocha test default timeout (to 10000) to avoid debug adapter test failures in git actions.