### PR TITLE
Add git actions to publish codecov

### DIFF
--- a/.github/workflows/publish-codecov1.yml
+++ b/.github/workflows/publish-codecov1.yml
@@ -1,0 +1,46 @@
+# Test build against released Ballerina distributions in the website
+name: Publish Codecov (Released dist)
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_dist_version:
+        description: Version of Ballerina distribution
+        required: true
+        default: swan-lake-preview5
+    branches: [master]
+
+jobs:
+  build:
+    name: Upload VSIX as release assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+      - name: Download ballerina distribution
+        uses: wei/wget@v1
+        with:
+          args: http://dist-dev.ballerina.io/downloads/${{ github.event.inputs.bal_dist_version }}/ballerina-${{ github.event.inputs.bal_dist_version }}.zip
+      - run: mkdir extractedDistribution
+      - name: Unzip ballerina distribution
+        uses: TonyBogdanov/zip@1.0
+        with:
+          args: unzip -qq ./ballerina-${{ github.event.inputs.bal_dist_version }}.zip -d ./extractedDistribution
+      - run: rm ballerina-${{ github.event.inputs.bal_dist_version }}.zip
+      - run: npm ci
+      - name: Build repository with tests
+        uses: GabrielBB/xvfb-action@v1.0
+        with:
+          run: ./gradlew clean build
+      - name: Publish codecov report
+        uses: codecov/codecov-action@v1
+        with:
+          directory: ./coverage/

--- a/.github/workflows/publish-codecov2.yml
+++ b/.github/workflows/publish-codecov2.yml
@@ -1,0 +1,46 @@
+# Test build against the Jenkins lastest built Ballerina distribution
+name: Publish Codecov (Jenkins built dist)
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_dist_version:
+        description: Version of Ballerina distribution
+        required: true
+        default: swan-lake-preview5
+    branches: [master]
+
+jobs:
+  build:
+    name: Upload VSIX as release assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+      - name: Download ballerina distribution
+        uses: wei/wget@v1
+        with:
+          args: https://wso2.org/jenkins/job/ballerina-platform/job/ballerina-distribution-build-pipeline/lastStableBuild/org.ballerinalang$ballerina/artifact/org.ballerinalang/ballerina/${{ github.event.inputs.bal_dist_version }}/ballerina-${{ github.event.inputs.bal_dist_version }}.zip
+      - run: mkdir extractedDistribution
+      - name: Unzip ballerina distribution
+        uses: TonyBogdanov/zip@1.0
+        with:
+          args: unzip -qq ./ballerina-${{ github.event.inputs.bal_dist_version }}.zip -d ./extractedDistribution
+      - run: rm ballerina-${{ github.event.inputs.bal_dist_version }}.zip
+      - run: npm ci
+      - name: Build repository with tests
+        uses: GabrielBB/xvfb-action@v1.0
+        with:
+          run: ./gradlew clean build
+      - name: Publish codecov report
+        uses: codecov/codecov-action@v1
+        with:
+          directory: ./coverage/


### PR DESCRIPTION
## Purpose
Add git actions to run tests with the released distribution and with the Jenkins built distribution, and publish codecov.